### PR TITLE
Speed up results_vs_r0

### DIFF
--- a/python/kolmogorov_EVP.py
+++ b/python/kolmogorov_EVP.py
@@ -498,16 +498,17 @@ def Sams_Lmat(N, f, k, m, A_Psi, A_T, A_C, flag, Pr, tau, R_0, Pm, H_b):
 
 
 def gamfromL(L, withmode=False):
-    w, v = np.linalg.eig(L)
     if withmode:
+        w, v = np.linalg.eig(L)
         ind = np.argmax(-np.imag(w))
         return [-np.imag(w[ind]), v[:, ind]]
     else:
+        w = np.linalg.eigvals(L)
         return np.max(-np.imag(w))
 
 
 def omegafromL(L):
-    w, v = np.linalg.eig(L)
+    w = np.linalg.eigvals(L)
     wsort = w[np.argsort(-np.imag(w))]
     return wsort[-1]
 
@@ -556,13 +557,14 @@ def sigma_from_fingering_params(delta, w, HB, DB, Pr, tau, R0, k_star, N, withmo
             A_C = -lhat * A_psi / (R0 * (lamhat + tau * l2hat))
             N_Sam = int((N-1)/2)  # Sam's definition of N is different than mine
             L = Sams_Lmat(N_Sam, 0, lhat, kz, A_psi, A_T, A_C, 0, Pr, tau, R0, Pr/DB, HB)
-            w, v = np.linalg.eig(L)
+            w = np.linalg.eigvals(L)
             ind = np.argmax(np.real(w))
             if get_frequency:
                 evalue = w[ind]
             else:
                 evalue = np.real(w[ind])
             if withmode:
+                w, v = np.linalg.eig(L)
                 return [evalue, v[:, ind]]
             else:
                 return evalue


### PR DESCRIPTION
This gave me a >10x speedup in running `paper_plot_fig8.py` by doing the following:
- Only calculate the eigenvalues when `withmode=False`, rather than calculating the eigenvectors and discarding them.
- Parallelize the loop over `r0s` in `results_vs_r0`. It looks like the previous call to `np.linalg.eig` was internally parallelized, while `np.linalg.eigvals` seemed to run single-threaded. So the speedup from only calculating the eigenvalues wasn't really apparent until this second step where the parallelism happens at a higher level.

With these modifications, I was able to run `paper_plot_fig8.py` in ~1 minute, comparable to the MESA implementation.

You may also need to do a quick `pip install joblib` for the parallel stuff.